### PR TITLE
Add modular trap beat generator with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ public/sampler.wasm
 public/safety_limiter.wasm
 public/equalizer.wasm
 public/lfo.wasm
+tests/dist

--- a/src/beatGenerator/TrapBeatGenerator.ts
+++ b/src/beatGenerator/TrapBeatGenerator.ts
@@ -1,0 +1,181 @@
+import type {
+  BeatGeneratorDependencies,
+  TrapBeatGeneratorPort,
+} from './domain/ports';
+import type {
+  TrapBeatConfig,
+  TrapBeatPattern,
+  RandomSource,
+  Patron,
+} from './domain/models';
+
+const createMulberry32 = (seed: number): RandomSource => {
+  let t = seed >>> 0;
+  return () => {
+    t += 0x6d2b79f5;
+    let r = Math.imul(t ^ (t >>> 15), t | 1);
+    r ^= r + Math.imul(r ^ (r >>> 7), r | 61);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+const defaultSwingForMode = (mode: TrapBeatConfig['mode']): number => {
+  if (mode === 'phrygianDom') {
+    return 0.2;
+  }
+  if (mode === 'harmonic') {
+    return 0.16;
+  }
+  return 0.14;
+};
+
+const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
+
+const applySwing = (
+  pattern: Patron,
+  swing: number,
+  bpm: number,
+  ritmo: BeatGeneratorDependencies['ritmo']
+): Patron => {
+  if (swing <= 0) {
+    return pattern;
+  }
+  const notas = pattern.notas.map(nota => {
+    const swungTime = ritmo.swing(nota.t, swing, bpm);
+    return { ...nota, t: swungTime };
+  });
+  return { ...pattern, notas };
+};
+
+export class TrapBeatGenerator implements TrapBeatGeneratorPort {
+  constructor(private readonly deps: BeatGeneratorDependencies) {}
+
+  generate(config: TrapBeatConfig): TrapBeatPattern {
+    const { bpm, compases, tonicMidi, mode } = config;
+    const random: RandomSource =
+      typeof config.randomSeed === 'number' ? createMulberry32(config.randomSeed) : () => Math.random();
+    const swing = clamp(config.swing ?? defaultSwingForMode(mode), 0, 0.25);
+    const melodyRange = config.melodyRange ?? [tonicMidi - 5, tonicMidi + 18];
+
+    const scaleMask = this.deps.escala.mask(tonicMidi % 12, mode);
+    const scaleNotes = this.deps.escala.buildScaleNotes(tonicMidi, mode, 3);
+
+    const baseProgression = this.deps.armonia.buildProgression({
+      compases,
+      tonicMidi,
+      mode,
+      scale: scaleNotes,
+      random,
+    });
+    const progression =
+      baseProgression.length > 0
+        ? baseProgression
+        : [
+            {
+              degree: 0,
+              notes: [tonicMidi, tonicMidi + 3, tonicMidi + 7, tonicMidi + 10],
+              bassNote: tonicMidi - 12,
+            },
+          ];
+
+    const melody = this.deps.melodia.generar({
+      compases,
+      bpm,
+      progression,
+      escala: this.deps.escala,
+      scaleMask,
+      tonic: tonicMidi,
+      rango: melodyRange,
+      random,
+    });
+
+    const hats = this.deps.percusion.generar({
+      compases,
+      bpm,
+      swing,
+      ritmo: this.deps.ritmo,
+      random,
+    });
+
+    const bass = this.deps.bajo.generar({
+      compases,
+      bpm,
+      progression,
+      escala: this.deps.escala,
+      tonic: tonicMidi,
+      mode,
+      random,
+    });
+
+    const swungMelody = applySwing(melody, swing, bpm, this.deps.ritmo);
+    const swungBass = applySwing(bass, swing * 0.6, bpm, this.deps.ritmo);
+
+    const humanizedMelody = this.deps.humanizer.humanize(swungMelody, {
+      bpm,
+      random,
+      timingStdMs: 8,
+      velocityStd: 6,
+    });
+    const humanizedHats = this.deps.humanizer.humanize(hats, {
+      bpm,
+      random,
+      timingStdMs: 4,
+      velocityStd: 10,
+    });
+    const humanizedBass = this.deps.humanizer.humanize(swungBass, {
+      bpm,
+      random,
+      timingStdMs: 6,
+      velocityStd: 4,
+    });
+
+    let darkness = this.deps.evaluator.disonancia(humanizedMelody, progression, { tonic: tonicMidi });
+    const ceiling = config.darknessCeiling ?? 6.5;
+    if (darkness > ceiling) {
+      const aligned = humanizedMelody.notas.map((nota, ix) => {
+        const barIx = Math.min(Math.floor(nota.t / 4), progression.length - 1);
+        const chord = progression[barIx]!;
+        const tones = this.deps.armonia.getChordTones(chord);
+        const closest = tones.reduce((best, tone) =>
+          Math.abs(tone - nota.midi) < Math.abs(best - nota.midi) ? tone : best
+        );
+        const mix = 0.5;
+        const corrected = Math.round(closest * mix + nota.midi * (1 - mix));
+        return { ...nota, midi: corrected };
+      });
+      const repairedMelody: Patron = { ...humanizedMelody, notas: aligned };
+      darkness = this.deps.evaluator.disonancia(repairedMelody, progression, { tonic: tonicMidi });
+      return {
+        melody: repairedMelody,
+        hats: humanizedHats,
+        bass808: humanizedBass,
+        chords: progression,
+        metadata: {
+          bpm,
+          swing,
+          tonicMidi,
+          mode,
+          compases,
+          darkness,
+        },
+      };
+    }
+
+    return {
+      melody: humanizedMelody,
+      hats: humanizedHats,
+      bass808: humanizedBass,
+      chords: progression,
+      metadata: {
+        bpm,
+        swing,
+        tonicMidi,
+        mode,
+        compases,
+        darkness,
+      },
+    };
+  }
+}
+
+export const TrapBeatGeneratorFactory = (deps: BeatGeneratorDependencies) => new TrapBeatGenerator(deps);

--- a/src/beatGenerator/domain/models.ts
+++ b/src/beatGenerator/domain/models.ts
@@ -1,0 +1,69 @@
+export interface Nota {
+  /**
+   * Timestamp in beats.
+   */
+  t: number;
+  /**
+   * Duration in beats.
+   */
+  dur: number;
+  /**
+   * MIDI note number (0-127).
+   */
+  midi: number;
+  /**
+   * MIDI velocity (0-127).
+   */
+  vel: number;
+}
+
+export interface GlideEvent {
+  start: number;
+  duration: number;
+  fromMidi: number;
+  toMidi: number;
+  curveK: number;
+}
+
+export interface Patron {
+  notas: Nota[];
+  glides?: GlideEvent[];
+}
+
+export type ScaleMode = 'minor' | 'harmonic' | 'phrygianDom';
+
+export interface Chord {
+  degree: number;
+  notes: number[];
+  bassNote: number;
+}
+
+export interface TrapBeatMetadata {
+  bpm: number;
+  swing: number;
+  tonicMidi: number;
+  mode: ScaleMode;
+  compases: number;
+  darkness: number;
+}
+
+export interface TrapBeatPattern {
+  melody: Patron;
+  hats: Patron;
+  bass808: Patron;
+  chords: Chord[];
+  metadata: TrapBeatMetadata;
+}
+
+export interface TrapBeatConfig {
+  bpm: number;
+  compases: number;
+  tonicMidi: number;
+  mode: ScaleMode;
+  swing?: number;
+  randomSeed?: number;
+  melodyRange?: [number, number];
+  darknessCeiling?: number;
+}
+
+export type RandomSource = () => number;

--- a/src/beatGenerator/domain/ports.ts
+++ b/src/beatGenerator/domain/ports.ts
@@ -1,0 +1,86 @@
+import type { Chord, Patron, RandomSource, ScaleMode, TrapBeatConfig, TrapBeatPattern } from './models';
+
+export interface EscalaService {
+  cuantizar(midi: number, mask: number[], tonic: number): number;
+  mask(tonic: number, modo: ScaleMode): number[];
+  buildScaleNotes(tonicMidi: number, modo: ScaleMode, octaves: number): number[];
+}
+
+export interface ArmoniaService {
+  buildProgression(config: {
+    compases: number;
+    tonicMidi: number;
+    mode: ScaleMode;
+    scale: number[];
+    random: RandomSource;
+  }): Chord[];
+  getChordTones(chord: Chord): number[];
+}
+
+export interface RitmoService {
+  euclid(k: number, n: number, offset?: number): boolean[];
+  swing(t: number, strength: number, bpm: number): number;
+}
+
+export interface MelodiaGenerator {
+  generar(config: {
+    compases: number;
+    bpm: number;
+    progression: Chord[];
+    escala: EscalaService;
+    scaleMask: number[];
+    tonic: number;
+    rango: [number, number];
+    random: RandomSource;
+  }): Patron;
+}
+
+export interface PercusionGenerator {
+  generar(config: {
+    compases: number;
+    bpm: number;
+    swing: number;
+    ritmo: RitmoService;
+    random: RandomSource;
+  }): Patron;
+}
+
+export interface Bajo808Generator {
+  generar(config: {
+    compases: number;
+    bpm: number;
+    progression: Chord[];
+    escala: EscalaService;
+    tonic: number;
+    mode: ScaleMode;
+    random: RandomSource;
+  }): Patron;
+}
+
+export interface Humanizer {
+  humanize(pattern: Patron, config: {
+    timingStdMs: number;
+    velocityStd: number;
+    bpm: number;
+    random: RandomSource;
+  }): Patron;
+}
+
+export interface Evaluator {
+  disonancia(pattern: Patron, progression: Chord[], config: { tonic: number }): number;
+}
+
+export interface TrapBeatGeneratorPort {
+  generate(config: TrapBeatConfig): TrapBeatPattern;
+}
+
+export interface BeatGeneratorDependencies {
+  escala: EscalaService;
+  armonia: ArmoniaService;
+  ritmo: RitmoService;
+  melodia: MelodiaGenerator;
+  percusion: PercusionGenerator;
+  bajo: Bajo808Generator;
+  humanizer: Humanizer;
+  evaluator: Evaluator;
+}

--- a/src/beatGenerator/index.ts
+++ b/src/beatGenerator/index.ts
@@ -1,0 +1,35 @@
+export * from './domain/models';
+export * from './domain/ports';
+export * from './TrapBeatGenerator';
+
+import { EscalaServiceFactory } from './services/EscalaService';
+import { ArmoniaServiceFactory } from './services/ArmoniaService';
+import { RitmoServiceFactory } from './services/RitmoService';
+import { MelodiaGeneratorFactory } from './services/MelodiaGenerator';
+import { PercusionGeneratorFactory } from './services/PercusionGenerator';
+import { Bajo808GeneratorFactory } from './services/Bajo808Generator';
+import { HumanizerFactory } from './services/Humanizer';
+import { EvaluatorFactory } from './services/Evaluator';
+import { TrapBeatGeneratorFactory } from './TrapBeatGenerator';
+
+export const createTrapBeatGenerator = () => {
+  const escala = EscalaServiceFactory();
+  const armonia = ArmoniaServiceFactory();
+  const ritmo = RitmoServiceFactory();
+  const melodia = MelodiaGeneratorFactory(armonia);
+  const percusion = PercusionGeneratorFactory();
+  const bajo = Bajo808GeneratorFactory();
+  const humanizer = HumanizerFactory();
+  const evaluator = EvaluatorFactory();
+
+  return TrapBeatGeneratorFactory({
+    escala,
+    armonia,
+    ritmo,
+    melodia,
+    percusion,
+    bajo,
+    humanizer,
+    evaluator,
+  });
+};

--- a/src/beatGenerator/services/ArmoniaService.ts
+++ b/src/beatGenerator/services/ArmoniaService.ts
@@ -1,0 +1,79 @@
+import type { ArmoniaService } from '../domain/ports';
+import type { Chord, ScaleMode, RandomSource } from '../domain/models';
+
+const DEGREE_PATTERNS: number[][] = [
+  [0, 5, 6, 5],
+  [0, 3, 4, 0],
+  [0, 6, 5, 6],
+];
+
+const choose = <T>(items: T[], random: RandomSource): T => {
+  const ix = Math.floor(random() * items.length);
+  return items[ix % items.length]!;
+};
+
+const wrap = (value: number, length: number) => ((value % length) + length) % length;
+
+const rotateToDegree = (scale: number[], degree: number): number[] => {
+  const octaveLength = scale.length / 3;
+  const rotated: number[] = [];
+  for (let octave = 0; octave < 3; octave += 1) {
+    for (let step = 0; step < octaveLength; step += 1) {
+      const ix = wrap(step + degree, octaveLength);
+      rotated.push(scale[ix] + octave * 12);
+    }
+  }
+  return rotated;
+};
+
+const buildChordNotes = (scale: number[], degree: number, size = 3): number[] => {
+  const rotated = rotateToDegree(scale, degree);
+  const notes: number[] = [];
+  for (let i = 0; i < size; i += 1) {
+    const ix = i * 2;
+    if (ix < rotated.length) {
+      notes.push(rotated[ix]);
+    }
+  }
+  return notes;
+};
+
+export class DefaultArmoniaService implements ArmoniaService {
+  buildProgression({
+    compases,
+    tonicMidi,
+    mode,
+    scale,
+    random,
+  }: {
+    compases: number;
+    tonicMidi: number;
+    mode: ScaleMode;
+    scale: number[];
+    random: RandomSource;
+  }): Chord[] {
+    const availablePatterns =
+      mode === 'phrygianDom' ? [DEGREE_PATTERNS[2], DEGREE_PATTERNS[1]] : DEGREE_PATTERNS;
+    const pattern = choose(availablePatterns, random);
+    const chords: Chord[] = [];
+    const ordered = [...scale].sort((a, b) => a - b);
+    if (ordered.length === 0) {
+      return chords;
+    }
+
+    for (let bar = 0; bar < compases; bar += 1) {
+      const degree = pattern[bar % pattern.length]!;
+      const notes = buildChordNotes(ordered, degree, 4);
+      const bassNote = Math.max(notes[0] - 12, tonicMidi - 24);
+      chords.push({ degree, notes, bassNote });
+    }
+
+    return chords;
+  }
+
+  getChordTones(chord: Chord): number[] {
+    return chord.notes;
+  }
+}
+
+export const ArmoniaServiceFactory = () => new DefaultArmoniaService();

--- a/src/beatGenerator/services/Bajo808Generator.ts
+++ b/src/beatGenerator/services/Bajo808Generator.ts
@@ -1,0 +1,77 @@
+import type { Bajo808Generator } from '../domain/ports';
+import type { Patron, Nota, RandomSource, Chord, GlideEvent } from '../domain/models';
+
+const EIGHTH = 0.5;
+
+const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
+
+const choose = <T>(items: T[], random: RandomSource): T => {
+  const ix = Math.floor(random() * items.length);
+  return items[ix % items.length]!;
+};
+
+const euclid = (k: number, n: number): boolean[] => {
+  const pattern: boolean[] = new Array(n).fill(false);
+  let accumulator = 0;
+  for (let i = 0; i < n; i += 1) {
+    accumulator += k;
+    if (accumulator >= n) {
+      accumulator -= n;
+      pattern[i] = true;
+    }
+  }
+  return pattern;
+};
+
+const selectBassPitch = (chord: Chord, tonic: number, random: RandomSource): number => {
+  const candidates = [chord.bassNote, chord.notes[0], chord.notes[0] - 5, chord.notes[0] - 7];
+  const choice = choose(candidates, random);
+  return clamp(choice, tonic - 36, tonic - 12);
+};
+
+export class DefaultBajo808Generator implements Bajo808Generator {
+  generar({ compases, bpm: _bpm, progression, escala, tonic, mode, random }: Parameters<Bajo808Generator['generar']>[0]): Patron {
+    const notas: Nota[] = [];
+    const glides: GlideEvent[] = [];
+    let previousNote: Nota | null = null;
+
+    for (let bar = 0; bar < compases; bar += 1) {
+      const chord = progression[bar % progression.length]!;
+      const pulses = random() > 0.5 ? 5 : 4;
+      const pattern = euclid(pulses, 8);
+      for (let step = 0; step < pattern.length; step += 1) {
+        if (!pattern[step] && random() > 0.2) {
+          continue;
+        }
+        const time = bar * 4 + step * EIGHTH;
+        const mask = escala.mask(tonic % 12, mode);
+        let midi = escala.cuantizar(selectBassPitch(chord, tonic, random), mask, tonic);
+        if (previousNote && Math.abs(previousNote.midi - midi) < 2) {
+          const alternatives = [chord.notes[0] - 12, chord.notes[0] - 7, chord.notes[0] - 5];
+          for (const alt of alternatives) {
+            const quantized = escala.cuantizar(alt, mask, tonic);
+            if (Math.abs(previousNote.midi - quantized) >= 2) {
+              midi = quantized;
+              break;
+            }
+          }
+        }
+        const duration = EIGHTH * (pattern[step] ? 0.9 : 0.5);
+        const velocity = clamp(108 + Math.floor(random() * 14) - 7, 80, 127);
+        const note: Nota = { t: time, dur: duration, midi, vel: velocity };
+        notas.push(note);
+
+        if (previousNote && previousNote.midi !== note.midi) {
+          const glideDuration = Math.min(duration, 0.75);
+          const curveK = 6 + random() * 4;
+          glides.push({ start: time, duration: glideDuration, fromMidi: previousNote.midi, toMidi: note.midi, curveK });
+        }
+        previousNote = note;
+      }
+    }
+
+    return { notas, glides };
+  }
+}
+
+export const Bajo808GeneratorFactory = () => new DefaultBajo808Generator();

--- a/src/beatGenerator/services/EscalaService.ts
+++ b/src/beatGenerator/services/EscalaService.ts
@@ -1,0 +1,64 @@
+import type { EscalaService } from '../domain/ports';
+import type { ScaleMode } from '../domain/models';
+
+const SCALE_MASKS: Record<ScaleMode, number[]> = {
+  minor: [1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 0],
+  harmonic: [1, 0, 1, 1, 0, 1, 0, 1, 0, 0, 1, 1],
+  phrygianDom: [1, 1, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0],
+};
+
+const SCALE_INTERVALS: Record<ScaleMode, number[]> = Object.fromEntries(
+  (Object.entries(SCALE_MASKS) as [ScaleMode, number[]][]).map(([mode, mask]) => [
+    mode,
+    mask
+      .map((value, ix) => ({ value, ix }))
+      .filter(({ value }) => value === 1)
+      .map(({ ix }) => ix),
+  ])
+) as Record<ScaleMode, number[]>;
+
+const mod = (n: number, m: number) => ((n % m) + m) % m;
+
+export class DefaultEscalaService implements EscalaService {
+  cuantizar(midi: number, mask: number[], tonic: number): number {
+    const pitchClass = mod(midi, 12);
+    if (mask[pitchClass] === 1) {
+      return midi;
+    }
+
+    for (let delta = 1; delta <= 6; delta += 1) {
+      const up = mod(pitchClass + delta, 12);
+      if (mask[up] === 1) {
+        return midi + delta;
+      }
+      const down = mod(pitchClass - delta, 12);
+      if (mask[down] === 1) {
+        return midi - delta;
+      }
+    }
+
+    return tonic;
+  }
+
+  mask(tonic: number, modo: ScaleMode): number[] {
+    const baseMask = SCALE_MASKS[modo];
+    const rotated = new Array(12).fill(0);
+    for (let i = 0; i < 12; i += 1) {
+      rotated[i] = baseMask[mod(i - tonic, 12)];
+    }
+    return rotated;
+  }
+
+  buildScaleNotes(tonicMidi: number, modo: ScaleMode, octaves: number): number[] {
+    const intervals = SCALE_INTERVALS[modo];
+    const notes: number[] = [];
+    for (let octave = 0; octave < octaves; octave += 1) {
+      for (const interval of intervals) {
+        notes.push(tonicMidi + interval + octave * 12);
+      }
+    }
+    return notes;
+  }
+}
+
+export const EscalaServiceFactory = () => new DefaultEscalaService();

--- a/src/beatGenerator/services/Evaluator.ts
+++ b/src/beatGenerator/services/Evaluator.ts
@@ -1,0 +1,42 @@
+import type { Evaluator } from '../domain/ports';
+import type { Patron, Chord } from '../domain/models';
+
+const EPS = 1e-6;
+
+const weightForTime = (t: number): number => {
+  const beatPos = t % 1;
+  if (beatPos < EPS) {
+    return 1.5;
+  }
+  if (beatPos < 0.5) {
+    return 1.1;
+  }
+  return 0.8;
+};
+
+const minDistanceToChord = (midi: number, chord: Chord): number => {
+  return chord.notes.reduce((min, tone) => Math.min(min, Math.abs(midi - tone)), Number.POSITIVE_INFINITY);
+};
+
+export class DefaultEvaluator implements Evaluator {
+  disonancia(pattern: Patron, progression: Chord[], { tonic }: { tonic: number }): number {
+    if (pattern.notas.length === 0 || progression.length === 0) {
+      return 0;
+    }
+
+    let acc = 0;
+    for (const nota of pattern.notas) {
+      const barIx = Math.max(0, Math.min(Math.floor(nota.t / 4), progression.length - 1));
+      const chord = progression[barIx]!;
+      const distance = minDistanceToChord(nota.midi, chord);
+      acc += weightForTime(nota.t) * distance;
+      if (nota.midi % 12 === (tonic + 1) % 12) {
+        acc += 0.5;
+      }
+    }
+
+    return acc / pattern.notas.length;
+  }
+}
+
+export const EvaluatorFactory = () => new DefaultEvaluator();

--- a/src/beatGenerator/services/Humanizer.ts
+++ b/src/beatGenerator/services/Humanizer.ts
@@ -1,0 +1,33 @@
+import type { Humanizer } from '../domain/ports';
+import type { Patron, Nota, RandomSource } from '../domain/models';
+
+const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
+
+const gaussian = (random: RandomSource): number => {
+  let u1 = 0;
+  let u2 = 0;
+  while (u1 === 0) u1 = random();
+  while (u2 === 0) u2 = random();
+  return Math.sqrt(-2.0 * Math.log(u1)) * Math.cos(2.0 * Math.PI * u2);
+};
+
+export class DefaultHumanizer implements Humanizer {
+  humanize(pattern: Patron, { timingStdMs, velocityStd, bpm, random }: Parameters<Humanizer['humanize']>[1]): Patron {
+    const beatDuration = 60 / bpm;
+    const timingStdBeats = (timingStdMs / 1000) / beatDuration;
+
+    const notas: Nota[] = pattern.notas.map(note => {
+      const timeJitter = gaussian(random) * timingStdBeats;
+      const velJitter = gaussian(random) * velocityStd;
+      return {
+        ...note,
+        t: note.t + timeJitter,
+        vel: clamp(Math.round(note.vel + velJitter), 0, 127),
+      };
+    });
+
+    return { ...pattern, notas };
+  }
+}
+
+export const HumanizerFactory = () => new DefaultHumanizer();

--- a/src/beatGenerator/services/MelodiaGenerator.ts
+++ b/src/beatGenerator/services/MelodiaGenerator.ts
@@ -1,0 +1,111 @@
+import type { MelodiaGenerator, ArmoniaService } from '../domain/ports';
+import type { Patron, Nota, RandomSource } from '../domain/models';
+
+const STEP_DISTRIBUTION: { step: number; weight: number }[] = [
+  { step: -1, weight: 0.35 },
+  { step: 1, weight: 0.25 },
+  { step: -2, weight: 0.18 },
+  { step: 2, weight: 0.12 },
+  { step: -3, weight: 0.06 },
+  { step: 3, weight: 0.04 },
+];
+
+const DURATION_DISTRIBUTION: { dur: number; weight: number }[] = [
+  { dur: 0.5, weight: 0.1 },
+  { dur: 0.25, weight: 0.25 },
+  { dur: 0.125, weight: 0.4 },
+  { dur: 0.0625, weight: 0.15 },
+  { dur: 1 / 12, weight: 0.06 },
+  { dur: 1 / 24, weight: 0.04 },
+];
+
+const EPS = 1e-6;
+
+const weightedChoice = <T extends { weight: number }>(options: T[], random: RandomSource): T => {
+  const total = options.reduce((sum, item) => sum + item.weight, 0);
+  const target = random() * total;
+  let acc = 0;
+  for (const option of options) {
+    acc += option.weight;
+    if (target <= acc) {
+      return option;
+    }
+  }
+  return options[options.length - 1]!;
+};
+
+const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
+
+const nearestChordTone = (note: number, tones: number[]): number => {
+  let best = tones[0]!;
+  let bestDist = Math.abs(note - best);
+  for (const tone of tones) {
+    const dist = Math.abs(note - tone);
+    if (dist < bestDist) {
+      best = tone;
+      bestDist = dist;
+    }
+  }
+  return best;
+};
+
+const isStrongBeat = (beat: number): boolean => Math.abs(beat % 1) < EPS;
+
+export class DefaultMelodiaGenerator implements MelodiaGenerator {
+  constructor(private readonly armonia: ArmoniaService) {}
+
+  generar({
+    compases,
+    bpm: _bpm,
+    progression,
+    escala,
+    scaleMask,
+    tonic,
+    rango,
+    random,
+  }: Parameters<MelodiaGenerator['generar']>[0]): Patron {
+    const totalBeats = compases * 4;
+    const notas: Nota[] = [];
+    if (progression.length === 0) {
+      return { notas };
+    }
+
+    const noteRange = rango;
+    let currentMidi = escala.cuantizar(progression[0]!.notes[0] ?? tonic, scaleMask, tonic);
+    currentMidi = clamp(currentMidi, noteRange[0], noteRange[1]);
+    let currentTime = 0;
+
+    while (currentTime < totalBeats - EPS) {
+      const remaining = totalBeats - currentTime;
+      const durationOption = weightedChoice(DURATION_DISTRIBUTION, random);
+      let duration = Math.min(durationOption.dur, remaining);
+      if (remaining < 0.0625) {
+        duration = remaining;
+      }
+
+      const step = weightedChoice(STEP_DISTRIBUTION, random).step;
+      let candidate = currentMidi + step;
+      candidate = clamp(candidate, noteRange[0], noteRange[1]);
+      candidate = escala.cuantizar(candidate, scaleMask, tonic);
+
+      const chordIx = Math.min(Math.floor(currentTime / 4), progression.length - 1);
+      const chord = progression[chordIx]!;
+      const chordTones = this.armonia.getChordTones(chord);
+      if (isStrongBeat(currentTime)) {
+        candidate = nearestChordTone(candidate, chordTones);
+      }
+
+      const velAccent = isStrongBeat(currentTime) ? 100 : 88;
+      const velocityVariance = Math.floor(random() * 12) - 6;
+      const velocity = clamp(velAccent + velocityVariance, 50, 120);
+
+      notas.push({ t: currentTime, dur: duration, midi: candidate, vel: velocity });
+      currentMidi = candidate - 0.2; // slight downward trend
+      currentTime += duration;
+    }
+
+    return { notas };
+  }
+}
+
+export const MelodiaGeneratorFactory = (armonia: ArmoniaService) => new DefaultMelodiaGenerator(armonia);

--- a/src/beatGenerator/services/PercusionGenerator.ts
+++ b/src/beatGenerator/services/PercusionGenerator.ts
@@ -1,0 +1,62 @@
+import type { PercusionGenerator } from '../domain/ports';
+import type { Patron, Nota, RandomSource } from '../domain/models';
+
+const SIXTEENTH = 0.25;
+
+const choose = <T>(items: T[], random: RandomSource): T => {
+  const ix = Math.floor(random() * items.length);
+  return items[ix % items.length]!;
+};
+
+const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
+
+const rollSubdivisions = [2, 3, 4, 6];
+
+const velocityForStep = (stepIx: number): number => {
+  if (stepIx % 4 === 0) {
+    return 108;
+  }
+  if (stepIx % 4 === 2) {
+    return 96;
+  }
+  return 82;
+};
+
+export class DefaultPercusionGenerator implements PercusionGenerator {
+  generar({ compases, bpm, swing, ritmo, random }: Parameters<PercusionGenerator['generar']>[0]): Patron {
+    const notas: Nota[] = [];
+    const rollsProbability = 0.35;
+    const hatDensity = 11;
+
+    for (let bar = 0; bar < compases; bar += 1) {
+      const basePattern = ritmo.euclid(hatDensity, 16, bar % 2 === 0 ? 0 : 1);
+      for (let step = 0; step < basePattern.length; step += 1) {
+        if (!basePattern[step] && random() > 0.1) {
+          continue;
+        }
+
+        const baseTime = bar * 4 + step * SIXTEENTH;
+        const hasRoll = basePattern[step] && random() < rollsProbability && step % 4 === 0;
+        const subdivision = hasRoll ? choose(rollSubdivisions, random) : 1;
+        const stepDuration = SIXTEENTH / subdivision;
+
+        for (let i = 0; i < subdivision; i += 1) {
+          const rawTime = baseTime + i * stepDuration;
+          const swingTime = swing > 0 ? ritmo.swing(rawTime, swing, bpm) : rawTime;
+          const jitter = (random() - 0.5) * 0.01;
+          const velocityVariation = Math.floor(random() * 10) - 5;
+          notas.push({
+            t: swingTime + jitter,
+            dur: stepDuration * 0.6,
+            midi: 42,
+            vel: clamp(velocityForStep(step) + velocityVariation, 50, 118),
+          });
+        }
+      }
+    }
+
+    return { notas };
+  }
+}
+
+export const PercusionGeneratorFactory = () => new DefaultPercusionGenerator();

--- a/src/beatGenerator/services/RitmoService.ts
+++ b/src/beatGenerator/services/RitmoService.ts
@@ -1,0 +1,48 @@
+import type { RitmoService } from '../domain/ports';
+
+const bjorklund = (pulses: number, steps: number): boolean[] => {
+  if (pulses <= 0) {
+    return new Array(steps).fill(false);
+  }
+  if (pulses >= steps) {
+    return new Array(steps).fill(true);
+  }
+
+  const pattern: boolean[] = new Array(steps).fill(false);
+  let bucket = 0;
+  for (let i = 0; i < steps; i += 1) {
+    bucket += pulses;
+    if (bucket >= steps) {
+      bucket -= steps;
+      pattern[i] = true;
+    }
+  }
+  return pattern;
+};
+
+export class DefaultRitmoService implements RitmoService {
+  euclid(k: number, n: number, offset = 0): boolean[] {
+    const base = bjorklund(k, n);
+    if (offset === 0) {
+      return base;
+    }
+    const rotated: boolean[] = [];
+    for (let i = 0; i < base.length; i += 1) {
+      rotated.push(base[(i + offset + base.length) % base.length]!);
+    }
+    return rotated;
+  }
+
+  swing(t: number, strength: number, bpm: number): number {
+    const beatDuration = 60 / bpm;
+    const eighthDuration = beatDuration / 2;
+    const position = t / eighthDuration;
+    const isOffbeat = Math.abs(position - Math.round(position)) > 1e-6 && Math.floor(position) % 2 === 0;
+    if (!isOffbeat) {
+      return t;
+    }
+    return t + strength * eighthDuration;
+  }
+}
+
+export const RitmoServiceFactory = () => new DefaultRitmoService();

--- a/tests/TrapBeatGenerator.test.ts
+++ b/tests/TrapBeatGenerator.test.ts
@@ -1,0 +1,57 @@
+import assert from 'assert';
+
+import { createTrapBeatGenerator } from '../src/beatGenerator';
+import { EscalaServiceFactory } from '../src/beatGenerator/services/EscalaService';
+import { RitmoServiceFactory } from '../src/beatGenerator/services/RitmoService';
+
+export const runTrapBeatGeneratorTests = () => {
+  const escala = EscalaServiceFactory();
+  const mask = escala.mask(0, 'harmonic');
+  assert.strictEqual(mask.length, 12, 'mask should contain 12 pitch classes');
+  assert.deepStrictEqual(mask, [1, 0, 1, 1, 0, 1, 0, 1, 0, 0, 1, 1], 'harmonic minor mask matches reference');
+
+  const quantized = escala.cuantizar(62, mask, 60);
+  const allowed = [0, 2, 3, 5, 7, 8, 11];
+  assert.strictEqual(allowed.includes(quantized % 12), true, 'quantized note should belong to scale');
+
+  const ritmo = RitmoServiceFactory();
+  const pattern = ritmo.euclid(5, 8);
+  assert.strictEqual(pattern.filter(Boolean).length, 5, 'euclidean pattern has expected pulses');
+
+  const generator = createTrapBeatGenerator();
+  const patternResult = generator.generate({
+    bpm: 142,
+    compases: 4,
+    tonicMidi: 54,
+    mode: 'harmonic',
+    randomSeed: 1337,
+    darknessCeiling: 8,
+    melodyRange: [54, 78],
+  });
+
+  assert.strictEqual(patternResult.chords.length, 4, 'chord progression should match compases');
+  assert.ok(patternResult.melody.notas.length > 0, 'melody must contain notes');
+  assert.ok(patternResult.hats.notas.length > 0, 'hats must contain notes');
+  assert.ok(patternResult.bass808.notas.length > 0, 'bass must contain notes');
+
+  const melodyMask = escala.mask(patternResult.metadata.tonicMidi % 12, patternResult.metadata.mode);
+  for (const nota of patternResult.melody.notas) {
+    assert.ok(
+      nota.midi >= 54 && nota.midi <= 78,
+      `melody midi ${nota.midi} stays within configured range`
+    );
+    assert.strictEqual(melodyMask[nota.midi % 12], 1, 'melody note aligns with scale mask');
+  }
+
+  const hatDensity = patternResult.hats.notas.length / patternResult.metadata.compases;
+  assert.ok(hatDensity > 8, 'hi-hat density fits trap expectations');
+
+  const glideCount = patternResult.bass808.glides?.length ?? 0;
+  assert.ok(glideCount >= 2, '808 pattern includes glides for expressiveness');
+
+  assert.ok(patternResult.metadata.darkness >= 0, 'darkness metric should be non-negative');
+  assert.ok(
+    patternResult.metadata.darkness <= 8,
+    `darkness metric ${patternResult.metadata.darkness} under configured ceiling`
+  );
+};

--- a/tests/run-tests.ts
+++ b/tests/run-tests.ts
@@ -1,0 +1,11 @@
+import { runTrapBeatGeneratorTests } from './TrapBeatGenerator.test';
+
+(async () => {
+  try {
+    runTrapBeatGeneratorTests();
+    console.log('Trap beat generator tests passed');
+  } catch (err) {
+    console.error('Test failure:', err);
+    process.exit(1);
+  }
+})();

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./dist",
+    "rootDir": "..",
+    "module": "commonjs",
+    "target": "es2020",
+    "types": ["node"],
+    "verbatimModuleSyntax": false
+  },
+  "include": ["../src/beatGenerator/**/*", "./**/*.ts"],
+  "exclude": ["../node_modules", "./dist"]
+}


### PR DESCRIPTION
## Summary
- add beat generation domain models, ports, and a trap-focused generator orchestrator
- implement scale, harmony, rhythm, melody, percussion, bass, humanizer, and evaluator services tuned for trap/drill workflows
- cover the new module with integration-style tests that verify scale quantization, Euclidean rhythm distribution, and glide generation

## Testing
- npx tsc --project tests/tsconfig.json
- node tests/dist/tests/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68cebcc895548333a9b38966b47ec29c